### PR TITLE
Add prop-types package to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dynamic-number",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Highly customizable react component for numbers",
   "keywords": [
     "react",
@@ -45,6 +45,7 @@
     "webpack": "^2.4.1"
   },
   "peerDependencies": {
+    "prop-types": "^15.5.8",
     "react": ">=0.14.5",
     "react-dom": ">=0.14.5"
   }


### PR DESCRIPTION
Oops, Sorry!
An error occurs if some user does not add a prop-types dependency.
I found [this issue](https://github.com/JedWatson/react-input-autosize/issues/82).
Please republish this in npm. It seems to be republish to the same version already published.
Sorry for making a mistake.